### PR TITLE
So I did some digging...

### DIFF
--- a/Loop1_With_Class.cpp
+++ b/Loop1_With_Class.cpp
@@ -8,16 +8,14 @@ class Alice{
 public:
 	int x;
 	char y;
-	
-	Alice(){
-		x=0;
-		y='a';
+
+	Alice():x(0),y('a'){
 	}
 };
 
 
 int main(){
-	
+
 	int i,arr_size=100000000;
 
 	//Create array of Alice class in memory; automatically calls constructor

--- a/Loop1_Without_Class.cpp
+++ b/Loop1_Without_Class.cpp
@@ -4,20 +4,10 @@ using namespace std;
 using namespace std::chrono;
 
 
-class Alice{
-public:
-	int x;
-	char y;
-	
-	Alice(){
-		x=0;
-		y='a';
-	}
-};
 
 
 int main(){
-	
+
 	int i,arr_size=100000000;
 
 	//Create separate arrays of x,y in memory and loop to initialize

--- a/rust_version/Cargo.toml
+++ b/rust_version/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "loop_without_class"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/rust_version/Cargo.toml
+++ b/rust_version/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+#criterion = { version = "0.5.1", features = [] }

--- a/rust_version/src/main.rs
+++ b/rust_version/src/main.rs
@@ -1,0 +1,56 @@
+#[derive(Clone, Copy)]
+struct Alice {
+    x: i32,
+    y: u8,
+}
+
+const ARR_SIZE: usize = 100000000;
+
+fn work_class(arr: &mut [Alice]) {
+    for (i, e) in arr.iter_mut().enumerate() {
+        e.x = i as i32;
+        e.y += (i % 10) as u8;
+    }
+}
+
+#[inline(never)]
+fn bench_class() -> Duration {
+    let a = Alice { x: 0, y: b'a' };
+    let mut arr = vec![a; ARR_SIZE];
+    work_class(arr.as_mut());
+    println!("Result is {}", arr[42].x); // if this is removed, call to work_class is optimized away (as it does nothing)
+    let t1 = Instant::now();
+    t1.elapsed()
+}
+
+use std::time::{Duration, Instant};
+
+fn work_arrays(x: &mut [i32], y: &mut [u8]) {
+    for i in 0..ARR_SIZE {
+        x[i] = i as i32;
+        y[i] += (i % 10) as u8;
+    }
+}
+
+#[inline(never)]
+fn bench_arrays() -> Duration {
+    let mut x = vec![0i32; ARR_SIZE];
+    let mut y = vec![0u8; ARR_SIZE];
+    let t1 = Instant::now();
+    work_arrays(x.as_mut(), y.as_mut());
+    t1.elapsed()
+}
+
+fn run_bench(name: &str, work: fn() -> Duration) {
+    let elapsed = work();
+    println!("{name} took {elapsed:?}");
+}
+
+fn main() {
+    //warmup
+    bench_class();
+    run_bench("Class/struct", bench_class);
+    //warmup again
+    bench_arrays();
+    run_bench("arrays", bench_arrays);
+}

--- a/rust_version/src/main.rs
+++ b/rust_version/src/main.rs
@@ -17,9 +17,8 @@ fn work_class(arr: &mut [Alice]) {
 fn bench_class() -> Duration {
     let a = Alice { x: 0, y: b'a' };
     let mut arr = vec![a; ARR_SIZE];
-    work_class(arr.as_mut());
-    println!("Result is {}", arr[42].x); // if this is removed, call to work_class is optimized away (as it does nothing)
     let t1 = Instant::now();
+    work_class(arr.as_mut());
     t1.elapsed()
 }
 

--- a/rust_version/src/main.rs
+++ b/rust_version/src/main.rs
@@ -1,11 +1,56 @@
+use std::time::{Duration, Instant};
+
+/// A function that is opaque to the optimizer, used to prevent the compiler from
+/// optimizing away computations in a benchmark.
+pub fn black_box<T>(dummy: T) -> T {
+    unsafe {
+        let ret = std::ptr::read_volatile(&dummy);
+        std::mem::forget(dummy);
+        ret
+    }
+}
 #[derive(Clone, Copy)]
 struct Alice {
     x: i32,
     y: u8,
 }
+// the most obnoxious OOP you've seen!
+#[allow(dead_code)]
+impl Alice {
+    fn get_x(&self) -> i32 {
+        self.x
+    }
+    fn set_x(&mut self, v: i32) {
+        self.x = v
+    }
+    fn get_y(&self) -> u8 {
+        self.y
+    }
+    fn set_y(&mut self, v: u8) {
+        self.y = v
+    }
+}
 
 const ARR_SIZE: usize = 100000000;
 
+#[inline(never)]
+fn work_class_with_setters(arr: &mut [Alice]) {
+    for (i, e) in arr.iter_mut().enumerate() {
+        e.set_x(i as i32);
+        e.set_y(e.get_y() + (i % 10) as u8);
+    }
+}
+
+fn bench_class_with_setters() -> Duration {
+    let a = Alice { x: 0, y: b'a' };
+    let mut arr = vec![a; ARR_SIZE];
+    let t1 = Instant::now();
+    work_class_with_setters(arr.as_mut());
+    black_box(arr);
+    t1.elapsed()
+}
+
+#[inline(never)]
 fn work_class(arr: &mut [Alice]) {
     for (i, e) in arr.iter_mut().enumerate() {
         e.x = i as i32;
@@ -13,30 +58,33 @@ fn work_class(arr: &mut [Alice]) {
     }
 }
 
-#[inline(never)]
 fn bench_class() -> Duration {
     let a = Alice { x: 0, y: b'a' };
     let mut arr = vec![a; ARR_SIZE];
     let t1 = Instant::now();
     work_class(arr.as_mut());
+    black_box(arr);
     t1.elapsed()
 }
 
-use std::time::{Duration, Instant};
-
+#[inline(never)]
 fn work_arrays(x: &mut [i32], y: &mut [u8]) {
+    let x = &mut x[0..ARR_SIZE];
+    let y = &mut y[0..ARR_SIZE];
+
     for i in 0..ARR_SIZE {
         x[i] = i as i32;
         y[i] += (i % 10) as u8;
     }
 }
 
-#[inline(never)]
 fn bench_arrays() -> Duration {
     let mut x = vec![0i32; ARR_SIZE];
     let mut y = vec![0u8; ARR_SIZE];
     let t1 = Instant::now();
     work_arrays(x.as_mut(), y.as_mut());
+    black_box(x);
+    black_box(y);
     t1.elapsed()
 }
 
@@ -49,6 +97,8 @@ fn main() {
     //warmup
     bench_class();
     run_bench("Class/struct", bench_class);
+    bench_class_with_setters();
+    run_bench("Class with setters", bench_class_with_setters);
     //warmup again
     bench_arrays();
     run_bench("arrays", bench_arrays);


### PR DESCRIPTION
Basically, the original benches are set up in a very inappropriate way - for all intents and purposes the execution time should be zero (as the main loop does not impact the final result of the program at all). However, compilers seem to struggle to figure that part out, such is life, but it is actually good for us.

Initially I've suspected different codegen due to class/struct messing with optimizer, see example here:
https://godbolt.org/z/PM5jTG676

But then I decided to make sure the optimizer is actually producing the codegen for the entire program as it should. As I am not a big pro in compiler details of C++, I've written a version of your tests in rust (as I find rustc more easy to control in this respect) and I've ended up finding a lot of interesting stuff. First, with the "correct" implementation of the benchmark, the array version is actually the slowest, despite using SIMD instructions (and the basic OO version does not). As expected, getters make no difference to the perf. This rabbit hole seems to go very deep, and leads to one conclusion - fast code is not "OO" or "non-OO", it is the code that was optimized well to run fast on particular hardware that it targets=) 